### PR TITLE
Enhancement/texture memory map unmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For this library to be a Vulkan 1.0 compatible implementation of NanoVG, while u
 - [X] Using Push constants in the Vertex Shader
 - [X] Optimizations to `vkCmdBindVertexBuffers` (call once per frame) and `vkCmdDraw` (use `firstVertex`)
 - [X] Using SSBO for single write of fragment data, rendered using uniform offset via pushConstant
-- [ ] Use triangle fan if supported on hardware
+- [X] Optimise texture memory flags, opt for `VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT` and single call to `vkMapMemory`.
 ---
 
 # 2024 - Im archive this.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For this library to be a Vulkan 1.0 compatible implementation of NanoVG, while u
 - [X] Using Push constants in the Vertex Shader
 - [X] Optimizations to `vkCmdBindVertexBuffers` (call once per frame) and `vkCmdDraw` (use `firstVertex`)
 - [X] Using SSBO for single write of fragment data, rendered using uniform offset via pushConstant
-- [X] Optimise texture memory flags, opt for `VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT` and single call to `vkMapMemory`.
+- [X] Optimise texture memory flags, only update descriptors if texture is present
 ---
 
 # 2024 - Im archive this.

--- a/example/example_vulkan.c
+++ b/example/example_vulkan.c
@@ -3,7 +3,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#define VK_ENABLE_BETA_EXTENSIONS
+#undef VK_USE_PLATFORM_XCB_KHR
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
@@ -87,8 +87,8 @@ void prepareFrame(VkDevice device, VkCommandBuffer cmd_buffer, FrameBuffers *fb)
   VkViewport viewport;
   viewport.width = (float) fb->buffer_size.width;
   viewport.height = (float) fb->buffer_size.height;
-  viewport.minDepth = (float) 0.0f;
-  viewport.maxDepth = (float) 1.0f;
+  viewport.minDepth = 0.0f;
+  viewport.maxDepth = 1.0f;
   viewport.x = (float) rp_begin.renderArea.offset.x;
   viewport.y = (float) rp_begin.renderArea.offset.y;
   vkCmdSetViewport(cmd_buffer, 0, 1, &viewport);
@@ -102,28 +102,6 @@ void submitFrame(VkDevice device, VkQueue graphicsQueue, VkQueue presentQueue, V
   VkResult res;
 
   vkCmdEndRenderPass(cmd_buffer);
-
-  VkImageMemoryBarrier image_barrier = {
-    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-    .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-    .dstAccessMask = 0,
-    .oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-    .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
-    .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-    .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-    .image = fb->swap_chain_buffers[fb->current_buffer].image,
-    .subresourceRange =
-      {
-        .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
-        .baseMipLevel = 0,
-        .levelCount = 1,
-        .baseArrayLayer = 0,
-        .layerCount = 1,
-      },
-  };
-  vkCmdPipelineBarrier(cmd_buffer, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                       0, 0, NULL, 0, NULL, 1, &image_barrier);
-
   vkEndCommandBuffer(cmd_buffer);
 
   VkPipelineStageFlags pipe_stage_flags = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
@@ -341,7 +319,7 @@ int main() {
       glfwGetCursorPos(window, &mx, &my);
 
       nvgBeginFrame(vg, (float) winWidth, (float) winHeight, pxRatio);
-      renderDemo(vg, (float) mx, (float) my, (float) winWidth, (float) winHeight, (float) t, blowup, &data);
+      renderDemo(vg, mx, my, (float) winWidth, (float) winHeight, t, blowup, &data);
       renderGraph(vg, 5, 5, &fps);
 
       nvgEndFrame(vg);

--- a/example/example_vulkan.c
+++ b/example/example_vulkan.c
@@ -3,7 +3,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#undef VK_USE_PLATFORM_XCB_KHR
 #define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 
@@ -102,6 +101,28 @@ void submitFrame(VkDevice device, VkQueue graphicsQueue, VkQueue presentQueue, V
   VkResult res;
 
   vkCmdEndRenderPass(cmd_buffer);
+
+  VkImageMemoryBarrier image_barrier = {
+    .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+    .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+    .dstAccessMask = 0,
+    .oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+    .newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+    .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+    .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+    .image = fb->swap_chain_buffers[fb->current_buffer].image,
+    .subresourceRange =
+      {
+        .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+        .baseMipLevel = 0,
+        .levelCount = 1,
+        .baseArrayLayer = 0,
+        .layerCount = 1,
+      },
+  };
+  vkCmdPipelineBarrier(cmd_buffer, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                       0, 0, NULL, 0, NULL, 1, &image_barrier);
+
   vkEndCommandBuffer(cmd_buffer);
 
   VkPipelineStageFlags pipe_stage_flags = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;

--- a/example/vulkan_util.h
+++ b/example/vulkan_util.h
@@ -273,7 +273,7 @@ static VkInstance createVkInstance(bool enable_debug_layer) {
   vkEnumerateInstanceLayerProperties(&layerCount, 0);
   VkLayerProperties *layerprop = malloc(sizeof(VkLayerProperties) * layerCount);
   vkEnumerateInstanceLayerProperties(&layerCount, layerprop);
-  printf("vkEnumerateInstanceLayerProperties:");
+  printf("vkEnumerateInstanceLayerProperties:\n");
   for (uint32_t i = 0; i < layerCount; ++i) {
     printf("%s\n", layerprop[i].layerName);
   }

--- a/example/vulkan_util.h
+++ b/example/vulkan_util.h
@@ -505,8 +505,6 @@ static void setupImageLayout(VkCommandBuffer cmdbuffer, VkImage image, VkImageAs
 
   VkImageSubresourceRange subresourceRange = {aspectMask, 0, 1, 0, 1};
   image_memory_barrier.subresourceRange = subresourceRange;
-  VkPipelineStageFlags src_stages = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-  VkPipelineStageFlags dest_stages = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 
   if (new_image_layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) {
     /* Make sure anything that was copying from this image has completed */
@@ -525,16 +523,11 @@ static void setupImageLayout(VkCommandBuffer cmdbuffer, VkImage image, VkImageAs
     /* Make sure any Copy or CPU writes to image are flushed */
     image_memory_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_INPUT_ATTACHMENT_READ_BIT;
   }
-  if (new_image_layout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) {
-    image_memory_barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-    image_memory_barrier.dstAccessMask = 0;
-    src_stages = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dest_stages = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-  }
 
   VkImageMemoryBarrier *pmemory_barrier = &image_memory_barrier;
 
-
+  VkPipelineStageFlags src_stages = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+  VkPipelineStageFlags dest_stages = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 
   vkCmdPipelineBarrier(cmdbuffer, src_stages, dest_stages, 0, 0, NULL, 0, NULL, 1, pmemory_barrier);
 }
@@ -581,7 +574,7 @@ VkRenderPass createRenderPass(VkDevice device, VkFormat color_format, VkFormat d
   attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
   attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
   attachments[0].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-  attachments[0].finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+  attachments[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
   attachments[1].format = depth_format;
   attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
@@ -594,7 +587,7 @@ VkRenderPass createRenderPass(VkDevice device, VkFormat color_format, VkFormat d
 
   VkAttachmentReference color_reference = {0};
   color_reference.attachment = 0;
-  color_reference.layout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+  color_reference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
   VkAttachmentReference depth_reference = {0};
   depth_reference.attachment = 1;
@@ -662,6 +655,7 @@ FrameBuffers createFrameBuffers(const VulkanDevice *device, VkSurfaceKHR surface
     colorSpace = surfFormats[0].colorSpace;
     free(surfFormats);
   }
+  colorFormat = VK_FORMAT_B8G8R8A8_UNORM;
 
   // Check the surface capabilities and formats
   VkSurfaceCapabilitiesKHR surfCapabilities;

--- a/src/nanovg.c
+++ b/src/nanovg.c
@@ -2399,7 +2399,6 @@ static float nvg__getFontScale(NVGstate* state)
 static void nvg__flushTextTexture(NVGcontext* ctx)
 {
 	int dirty[4];
-
 	if (fonsValidateTexture(ctx->fs, dirty)) {
 		int fontImage = ctx->fontImages[ctx->fontImageIdx];
 		// Update texture

--- a/src/nanovg_vk.h
+++ b/src/nanovg_vk.h
@@ -1406,7 +1406,7 @@ static int vknvg_renderCreateTexture(void *uptr, int type, int w, int h, int ima
 
   mem_alloc.allocationSize = mem_reqs.size;
 
-  VkFlags flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+  VkFlags flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
   VkResult res = vknvg_memory_type_from_properties(vk->memoryProperties, mem_reqs.memoryTypeBits, flags, &mem_alloc.memoryTypeIndex);
   assert(res == VK_SUCCESS);
 
@@ -1557,7 +1557,7 @@ static void vknvg_renderFlush(void *uptr) {
 
   int i;
   if (vk->ncalls > 0) {
-    VkFlags flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    VkFlags flags =VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vknvg_UpdateBuffer(device, allocator, &vk->vertexBuffer[currentFrame], memoryProperties, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, flags, vk->verts, vk->nverts * sizeof(vk->verts[0]));
     vknvg_UpdateBuffer(device, allocator, &vk->fragUniformBuffer[currentFrame], memoryProperties, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, flags, vk->uniforms, vk->nuniforms * vk->fragSize);
 

--- a/src/nanovg_vk.h
+++ b/src/nanovg_vk.h
@@ -1361,7 +1361,7 @@ static int vknvg_renderCreate(void *uptr) {
 }
 
 static int vknvg_renderCreateTexture(void *uptr, int type, int w, int h, int imageFlags, const unsigned char *data) {
-  VKNVGcontext *vk = (VKNVGcontext *) uptr;
+  VKNVGcontext *vk = uptr;
   VKNVGtexture *tex = vknvg_allocTexture(vk);
   if (!tex) {
     return 0;
@@ -1477,7 +1477,7 @@ static int vknvg_renderCreateTexture(void *uptr, int type, int w, int h, int ima
     if (type == NVG_TEXTURE_RGBA)
       tx_format = 4;
     size_t texture_size = w * h * tx_format * sizeof(uint8_t);
-    uint8_t *generated_texture = (uint8_t *) malloc(texture_size);
+    uint8_t *generated_texture = malloc(texture_size);
     for (uint32_t i = 0; i < (uint32_t) w; ++i) {
       for (uint32_t j = 0; j < (uint32_t) h; ++j) {
         size_t pixel = (i + j * w) * tx_format * sizeof(uint8_t);
@@ -1501,7 +1501,7 @@ static int vknvg_renderCreateTexture(void *uptr, int type, int w, int h, int ima
 }
 static int vknvg_renderDeleteTexture(void *uptr, int image) {
 
-  VKNVGcontext *vk = (VKNVGcontext *) uptr;
+  VKNVGcontext *vk = uptr;
 
   VKNVGtexture *tex = vknvg_findTexture(vk, image);
 
@@ -1513,7 +1513,6 @@ static int vknvg_renderDeleteTexture(void *uptr, int image) {
 }
 static int vknvg_renderUpdateTexture(void *uptr, int image, int x, int y, int w, int h, const unsigned char *data) {
   VKNVGcontext *vk = uptr;
-
   VKNVGtexture *tex = vknvg_findTexture(vk, image);
   vknvg_UpdateTexture(vk->createInfo.device, tex, x, y, w, h, data);
   return 1;
@@ -1834,7 +1833,7 @@ error:
 
 static void vknvg_renderDelete(void *uptr) {
 
-  VKNVGcontext *vk = (VKNVGcontext *) uptr;
+  VKNVGcontext *vk = uptr;
 
   VkDevice device = vk->createInfo.device;
   const VkAllocationCallbacks *allocator = vk->createInfo.allocator;

--- a/src/nanovg_vk.h
+++ b/src/nanovg_vk.h
@@ -1406,7 +1406,7 @@ static int vknvg_renderCreateTexture(void *uptr, int type, int w, int h, int ima
 
   mem_alloc.allocationSize = mem_reqs.size;
 
-  VkFlags flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+  VkFlags flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
   VkResult res = vknvg_memory_type_from_properties(vk->memoryProperties, mem_reqs.memoryTypeBits, flags, &mem_alloc.memoryTypeIndex);
   assert(res == VK_SUCCESS);
 
@@ -1557,7 +1557,7 @@ static void vknvg_renderFlush(void *uptr) {
 
   int i;
   if (vk->ncalls > 0) {
-    VkFlags flags =VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT |VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    const VkFlags flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
     vknvg_UpdateBuffer(device, allocator, &vk->vertexBuffer[currentFrame], memoryProperties, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, flags, vk->verts, vk->nverts * sizeof(vk->verts[0]));
     vknvg_UpdateBuffer(device, allocator, &vk->fragUniformBuffer[currentFrame], memoryProperties, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, flags, vk->uniforms, vk->nuniforms * vk->fragSize);
 


### PR DESCRIPTION
 - Optimising texture memory, device local quick map
 - Adding clang-format files of consistency in formatting accross environments
 - Collapsed shaders into one permuation. Toggles using specialization constants
 - Usung SSBO Instead of UBO, writes fragment attributes once per frame